### PR TITLE
Fix issue with geoip file format

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -2,7 +2,9 @@
 
 # file: roles/ansible-xtables_geoip/defaults/main.yaml
 
-xtables_geoip_tmp_download_dir: '/tmp/geoip_tmp_download_dir'
-xtables_geoip_download_cmd: '/usr/lib/xtables-addons/xt_geoip_dl'
-xtables_geoip_directory: '/usr/share/xt_geoip'
-xtables_geoip_build_cmd: '/usr/lib/xtables-addons/xt_geoip_build'
+xtables_geoip_scripts:
+  - "geoip-update.sh"
+  - "GeoLite2xtables.pl"
+xtables_geoip_scripts_dir: "/usr/local/bin"
+xtables_geoip_update_script_path: "{{ xtables_geoip_scripts_dir }}/geoip-update.sh"
+xtables_geoip_update_script_logs: "/var/log/geoip-update.log"

--- a/files/GeoLite2xtables.pl
+++ b/files/GeoLite2xtables.pl
@@ -1,0 +1,99 @@
+#!/usr/bin/perl -w
+use strict;
+use diagnostics;
+use NetAddr::IP;
+use Getopt::Long;
+
+my $quiet = 0;
+GetOptions(
+    'quiet' => \$quiet,
+    ) or die("bad args");
+
+unless(-s "$ARGV[0]"){
+  print STDERR "Specify Country DB to use on the command line.\n";
+  exit 1;
+}
+
+# Prime country data with additional continent codes
+# http://download.geonames.org/export/dump/readme.txt
+my $countryinfo;
+$countryinfo->{'6255146'}->{'code'} = 'AF';
+$countryinfo->{'6255146'}->{'name'} = 'Africa';
+$countryinfo->{'6255147'}->{'code'} = 'AS';
+$countryinfo->{'6255147'}->{'name'} = 'Asia';
+$countryinfo->{'6255148'}->{'code'} = 'EU';
+$countryinfo->{'6255148'}->{'name'} = 'Europe';
+$countryinfo->{'6255149'}->{'code'} = 'NA';
+$countryinfo->{'6255149'}->{'name'} = 'North America';
+$countryinfo->{'6255150'}->{'code'} = 'SA';
+$countryinfo->{'6255150'}->{'name'} = 'South America';
+$countryinfo->{'6255151'}->{'code'} = 'OC';
+$countryinfo->{'6255151'}->{'name'} = 'Oceania';
+$countryinfo->{'6255152'}->{'code'} = 'AN';
+$countryinfo->{'6255152'}->{'name'} = 'Antarctica';
+
+# Read the countryinfo file
+open my $fh_in, "<", "$ARGV[0]" or die "Can't open $ARGV[0]: $!\n";
+foreach my $line (<$fh_in>){
+  chomp $line;
+  next if ($line =~ /^#/);
+  my @fields = (split "\t", $line);
+  my $code = $fields[0];
+  my $name = $fields[4];
+  my $id   = $fields[16];
+  $countryinfo->{$id}->{'code'} = $code;
+  $countryinfo->{$id}->{'name'} = $name;
+}
+close $fh_in;
+
+# Convert actual GeoLite2 data from STDIN
+my $counter;
+foreach my $line (<STDIN>){
+  next unless ($line =~ /^\d/);
+  chomp $line;
+  $counter++;
+  my @fields = (split ",", $line);
+  my $network = $fields[0];
+  my $geoname_id = $fields[1];
+  my $registered_country_geoname_id = $fields[2];
+  my $represented_country_geoname_id = $fields[3];
+  my $is_anonymous_proxy = $fields[4];
+  my $is_satellite_provider = $fields[5];
+  my $ip = NetAddr::IP->new($network);
+  my $start_ip = $ip->canon();
+  my $end_ip = $ip->broadcast();
+  my $start_int = $ip->bigint();
+  my $end_int = $end_ip->bigint();
+  my $code;
+  my $name;
+  if ($is_anonymous_proxy){
+    $code = "A1";
+    $name = "Anonymous Proxy";
+  }elsif ($is_satellite_provider){
+    $code = "A2";
+    $name = "Satellite Provider";
+  }elsif($countryinfo->{$represented_country_geoname_id}){
+    $code = $countryinfo->{$represented_country_geoname_id}->{'code'};
+    $name = $countryinfo->{$represented_country_geoname_id}->{'name'};
+  }elsif($countryinfo->{$registered_country_geoname_id}){
+    $code = $countryinfo->{$registered_country_geoname_id}->{'code'};
+    $name = $countryinfo->{$registered_country_geoname_id}->{'name'};
+  }elsif($countryinfo->{$geoname_id}){
+    $code = $countryinfo->{$geoname_id}->{'code'};
+    $name = $countryinfo->{$geoname_id}->{'name'};
+  }else{
+    print STDERR "Unknown Geoname ID, panicking. This is a bug.\n";
+    print STDERR "ID: $geoname_id\n";
+    print STDERR "ID Registered: $registered_country_geoname_id\n";
+    print STDERR "ID Represented $represented_country_geoname_id\n";
+    exit 1;
+  }
+
+  # Legacy GeoIP listing format:
+  # "1.0.0.0","1.0.0.255","16777216","16777471","AU","Australia"
+  printf "\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\"\n",
+    $start_ip, $end_ip->canon(), $start_int, $end_int, $code, $name;
+  if (!$quiet && $counter % 10000 == 0) {
+    print STDERR "$counter\n";
+  }
+}

--- a/files/geoip-update.sh
+++ b/files/geoip-update.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+function downloadGeoIPFiles() {
+
+  WriteInfo "Remove temporary download directory ..."
+  rm -rf "${xt_geoip_tmp_dir}" || { WriteErr "'rm -rf ${xt_geoip_tmp_dir}' failed"; return 1; }
+
+  WriteInfo "Create new temporary download directory ..."
+  mkdir -p -m 755 "${xt_geoip_tmp_dir}" || { WriteErr "'mkdir -p -m 755 ${xt_geoip_tmp_dir}' failed"; return 1; }
+
+  WriteInfo "moving into temporary download directory"
+  cd "${xt_geoip_tmp_dir}" || { WriteErr "'cd ${xt_geoip_tmp_dir}' failed"; return 1; }
+
+  WriteInfo "Downloading new country files (in ${PWD})"
+
+  for zipfile in ${geoip_zipfiles}
+  do
+    echo "Downloading '${zipfile}'"
+    wget "${geoip_baseurl}/${zipfile}" || { WriteErr "'wget ${geoip_baseurl}/${zipfile}' failed"; return 1; }
+  done
+
+  for zipfile in ${geoip_zipfiles}
+  do
+    echo "Unzippping '${zipfile}'"
+    unzip "${zipfile}" || { WriteErr "'unzip ${zipfile}' failed"; return 1; }
+  done
+
+  echo "Downloading '${countryinfo_file}'"
+  wget "${countryinfo_baseurl}/${countryinfo_file}" || { WriteErr "'wget ${countryinfo_baseurl}/${countryinfo_file}' failed"; return 1; }
+
+  return 0
+}
+
+function buildGeoIPDatabase() {
+
+  WriteInfo "moving into temporary download directory"
+  cd "${xt_geoip_tmp_dir}" || { WriteErr "'cd ${xt_geoip_tmp_dir}' failed"; return 1; }
+
+  WriteInfo "Building new geoip database (${PWD}) ..."
+  for csv_file in $(find "${xt_geoip_tmp_dir}" -type f -name "GeoLite2-Country-Blocks*.csv")
+  do
+    # see https://github.com/mschmitt/GeoLite2xtables
+    echo "Converting '${csv_file}' into a working format (workaround)"
+    cat "${csv_file}" | ${GeoLite2xtables_tool} "${countryinfo_file}" > "${csv_file}.converted" || { WriteErr "'${GeoLite2xtables_tool}' failed"; return 1; }
+    echo "Processing '${csv_file}.converted'"
+    ${xt_geoip_build_tool} "${csv_file}.converted" || { WriteErr "'${xt_geoip_build_tool} ${csv_file}.converted' failed"; return 1; }
+  done
+
+  return 0
+}
+
+function replaceGeoIPDatabase() {
+  rgid_timestamp=$(date +%d%m%Y-%H%M%S)
+  rgid_xt_geoip_backup_dir="${xt_geoip_dir}_${rgid_timestamp}"
+
+  if [ -d "${xt_geoip_dir}" ]; then
+    WriteInfo "Backup current database directory ..."
+    mv "${xt_geoip_dir}" "${rgid_xt_geoip_backup_dir}" || { WriteErr "' mv ${rgid_xt_geoip_dir} ${rgid_xt_geoip_backup_dir}' failed"; return 1; }
+  fi
+
+  WriteInfo "Move new database directory in place ..."
+  mv "${xt_geoip_tmp_dir}" "${xt_geoip_dir}" || { WriteErr "'mv ${rgid_xt_geoip_tmp_dir} ${rgid_xt_geoip_dir}' failed"; return 1; }
+
+  if [ -d "${rgid_xt_geoip_backup_dir}" ]; then
+    WriteInfo "Purge old database directory"
+    rm -r "${rgid_xt_geoip_backup_dir}" || { WriteErr "'rm -r ${rgid_xt_geoip_backup_dir}' failed"; return 1; }
+  fi
+
+  return 0
+}
+
+function WriteInfo() {
+  wi_timestamp=$(date +%d/%m/%Y-%H:%M:%S)
+  echo "${wi_timestamp}|INFO: ${1}"
+}
+
+function WriteWarn() {
+  ww_timestamp=$(date +%d/%m/%Y-%H:%M:%S)
+  echo "${ww_timestamp}|WARNING: ${1}"
+}
+
+function WriteErr() {
+  we_timestamp=$(date +%d/%m/%Y-%H:%M:%S)
+  echo "${we_timestamp}|ERROR: ${1}"
+}
+
+function ExitScript() {
+  es_exit_status=${1:=0}
+  es_exit_text="${2}"
+  [ -z "${es_exit_text}" ] && es_exit_text="Exit with status '${es_exit_status}'"
+  if [ ${es_exit_status} -eq 0 ]; then
+    WriteInfo "${es_exit_text}"
+  else
+    WriteErr "${es_exit_text}"
+  fi
+  exit "${es_exit_status}"
+}
+
+# main()
+
+export PATH="/sbin:/bin:/usr/sbin:/usr/bin"
+
+#geoip_zipfiles="GeoLite2-City-CSV.zip
+geoip_zipfiles="GeoLite2-Country-CSV.zip"
+geoip_baseurl="https://geolite.maxmind.com/download/geoip/database"
+countryinfo_baseurl="https://download.geonames.org/export/dump"
+countryinfo_file="countryInfo.txt"
+GeoLite2xtables_tool="/usr/local/bin/GeoLite2xtables.pl"
+xt_geoip_download_tool="/usr/lib/xtables-addons/xt_geoip_dl"
+xt_geoip_build_tool="/usr/lib/xtables-addons/xt_geoip_build"
+xt_geoip_dir="/usr/share/xt_geoip"
+xt_geoip_tmp_dir="/usr/share/xt_geoip_new"
+
+downloadGeoIPFiles || ExitScript 1 "Failed downloading new geoip files"
+
+buildGeoIPDatabase || ExitScript 1 "Failed building new geoip database"
+
+replaceGeoIPDatabase || ExitScript 1 "Failed replacing old geoip database"
+
+ExitScript 0 "Completed geoip database update"

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -2,30 +2,36 @@
 
 # file: roles/ansible-xtables_geoip/tasks/main.yml
 
-
 - name: ensure xtables packages are installed
-  apt: pkg={{ item }} state=installed
-  with_items: xtables_geoip_packages
+  apt:
+    name: "{{ xtables_geoip_packages }}"
+    state: "present"
+    update_cache: true
+    cache_valid_time: "3600"
 
-- name: create temporary download folder
-  file:
-    path: '{{ xtables_geoip_tmp_download_dir }}'
-    state: directory
-    mode: '0700'
+- name: "push geoip-update scripts"
+  copy:
+    src: "{{ script }}"
+    dest: "{{ xtables_geoip_scripts_dir }}"
+    owner: "root"
+    group: "root"
+    mode: "0755"
+  loop: "{{ xtables_geoip_scripts }}"
+  loop_control:
+    loop_var: script
 
-- name: download geoip files
-  shell: "cd {{ xtables_geoip_tmp_download_dir }}; {{ xtables_geoip_download_cmd }}"
+- name: "setup cron job for geoip update script"
+  copy:
+    content: |
+      0 0 1 * * root {{ xtables_geoip_update_script_path }} >> {{ xtables_geoip_update_script_logs }} 2>&1
+      0 1 1 1 * root /bin/mv -f {{ xtables_geoip_update_script_logs }} {{ xtables_geoip_update_script_logs }}.1
+    dest: "/etc/cron.d/geoip-update"
+    owner: "root"
+    group: "root"
+    mode: "0644"
 
-- name: create xtables geoip directory
-  file:
-    path: '{{ xtables_geoip_directory }}'
-    state: directory
-    mode: '0700'
-
-- name: convert geoip files for xtables
-  shell: "{{ xtables_geoip_build_cmd }} -D {{ xtables_geoip_directory }} {{ xtables_geoip_tmp_download_dir }}/*.csv"
-
-- name: cleanup temporary download folder
-  file:
-    path: '{{ xtables_geoip_tmp_download_dir }}'
-    state: absent
+- name: "initial geoip update run"
+  shell: >
+    {{ xtables_geoip_update_script_path }} > {{ xtables_geoip_update_script_logs }} 2>&1
+  args:
+    creates: "{{ xtables_geoip_update_script_logs }}"

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -1,9 +1,9 @@
 ---
 
-# file: # file: : roles/ansible-xtables_geoip/vars/main.yaml
+# file: roles/ansible-xtables_geoip/vars/main.yaml
 
 xtables_geoip_packages:
-  - linux-headers-generic
-  - xtables-addons-common
-  - libtext-csv-xs-perl
-  - geoip-database-contrib
+  - "xtables-addons-common"
+  - "libtext-csv-xs-perl"
+  - "geoip-bin"
+  - "libnetaddr-ip-perl"


### PR DESCRIPTION
Since January 2019, the file format of geoip files have changed
and the toolchain to process and integrate them is broken

The changes are a workaround so the filtering continues to work.